### PR TITLE
Fix json type return

### DIFF
--- a/docker_pull.py
+++ b/docker_pull.py
@@ -166,7 +166,7 @@ for layer in layers:
 	# last layer = config manifest - history - rootfs
 	if layers[-1]['digest'] == layer['digest']:
 		# FIXME: json.loads() automatically converts to unicode, thus decoding values whereas Docker doesn't
-		json_obj = json.loads(confresp.content)
+		json_obj = json.loads(confresp.content.decode('utf-8'))
 		del json_obj['history']
 		try:
 			del json_obj['rootfs']

--- a/docker_pull.py
+++ b/docker_pull.py
@@ -166,7 +166,7 @@ for layer in layers:
 	# last layer = config manifest - history - rootfs
 	if layers[-1]['digest'] == layer['digest']:
 		# FIXME: json.loads() automatically converts to unicode, thus decoding values whereas Docker doesn't
-		json_obj = json.loads(confresp.content.decode('utf-8'))
+		json_obj = json.loads(confresp.content)
 		del json_obj['history']
 		try:
 			del json_obj['rootfs']


### PR DESCRIPTION
Sometimes json return is of a non-valid types such as 'byte' and this breaks the image assembly.

Setting type to utf solves this issue.